### PR TITLE
Add functions for submitting and retrieving form responses from google sheets

### DIFF
--- a/pages/form/5.js
+++ b/pages/form/5.js
@@ -5,6 +5,7 @@ import useForm from "../../components/FormProvider";
 import { departments } from "../../utils/constants";
 import LinkButton from "../../components/LinkButton/LinkButton";
 import capitalize from "../../utils/capitalize";
+import { sendFormResponse } from "../../utils/dbApi";
 
 export default function Question5() {
   const { answers, setAnswers } = useForm();
@@ -32,11 +33,13 @@ export default function Question5() {
       <LinkButton
         href="/results"
         disabled={!department}
-        onClick={() =>
-          setAnswers((prev) => ({
-            ...prev,
-            department,
-          }))
+        onClick={() => 
+          setAnswers((prev) => {
+            const response = { ...prev, department };
+            //console.log(`form 5 updates: ${JSON.stringify(response)}`);
+            sendFormResponse(response);
+            return response;
+          })
         }
       >
         Calculate!

--- a/pages/results.js
+++ b/pages/results.js
@@ -5,10 +5,12 @@ import Layout from "../components/Layout/Layout";
 import calculateEmissions from "../utils/calculateEmissions";
 import capitalize from "../utils/capitalize";
 import { daysOfWeek } from "../utils/constants";
+import { getFormResponses } from "../utils/dbApi";
 
 export default function Results() {
   const { answers } = useForm();
   const { km, transportModes, department, incentive } = answers;
+  const { form_responses } = getFormResponses();
   const results = calculateEmissions(km, transportModes);
 
   return (

--- a/utils/dbApi.js
+++ b/utils/dbApi.js
@@ -1,0 +1,28 @@
+const url = 'http://localhost:8080';
+// const url = 'https://australia-southeast1-civic-maker-x.cloudfunctions.net/submitFormResponses';
+
+export const sendFormResponse = async (resp) => {
+  const params = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(resp),
+  };
+  const apiResponse = await fetch(url, params);
+  const text = await apiResponse.text();
+  console.log(`sendFormResponse : (status: ${apiResponse.status}) ${JSON.stringify(text, null, '\t')}`);
+};
+
+export const getFormResponses = async () => {
+  const params = {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  };
+  const apiResponse = await fetch(url, params);
+  const text = await apiResponse.text();
+  console.log(`getFormResponses : (status: ${apiResponse.status}) ${JSON.stringify(text, null, '\t')}`);
+  return text;
+};


### PR DESCRIPTION
**N.B:**
- the code that implements api for access google sheets (db) isn't in this PR!
- [`utils/dbApi.js:sendFormResponse()`](https://github.com/CodeforAustralia/council-emissions-calculator-spike/compare/main...hqtan:add-api-for-db?expand=1#diff-90ce3c7e3f364a7a3e82f1f527c17b8c6a5fb6115f5def2000809a51fb5b950dR4) submits the JSON data containing form response to api (currently configured as [`http://localhost:8080`](https://github.com/CodeforAustralia/council-emissions-calculator-spike/compare/main...hqtan:add-api-for-db?expand=1#diff-90ce3c7e3f364a7a3e82f1f527c17b8c6a5fb6115f5def2000809a51fb5b950dR1))
-  [`utils/dbApi.js:getFormResponses()`](https://github.com/CodeforAustralia/council-emissions-calculator-spike/compare/main...hqtan:add-api-for-db?expand=1#diff-90ce3c7e3f364a7a3e82f1f527c17b8c6a5fb6115f5def2000809a51fb5b950dR17) retrieves all form responses from google sheets
- also added a bunch of console logging for troubleshooting :sweat_smile: ...