### PR TITLE
Layout

### DIFF
--- a/components/Layout/Layout.jsx
+++ b/components/Layout/Layout.jsx
@@ -13,10 +13,10 @@ export default function Layout({ children }) {
         <meta name="description" content="Emissions calculator" />
         <link rel="icon" href={`${productionUrl}/favicon.ico`} />
       </Head>
+      <Flex alignItems="center" height={titleBarHeight} pos="fixed" top="0" w="100%" bg="#055E9E" color="white" zIndex={10}>
+        <Text pl="3.5rem" fontSize="2.25rem" fontWeight="bold">SeeChange</Text>
+      </Flex>
       <Flex alignItems="center" minHeight={`calc(100vh - ${titleBarHeight})`} pos="relative" top={titleBarHeight} py={5}>
-        <Flex alignItems="center" height={titleBarHeight} pos="fixed" top="0" w="100%" bg="#055E9E" color="white" zIndex={10}>
-          <Text pl="3.5rem" fontSize="2.25rem" fontWeight="bold">SeeChange</Text>
-        </Flex>
         <Container centerContent maxW="container.sm">
           {children}
         </Container>

--- a/components/Layout/Layout.jsx
+++ b/components/Layout/Layout.jsx
@@ -13,10 +13,10 @@ export default function Layout({ children }) {
         <meta name="description" content="Emissions calculator" />
         <link rel="icon" href={`${productionUrl}/favicon.ico`} />
       </Head>
-      <Flex alignItems="center" height={titleBarHeight} pos="fixed" top="0" w="100%" bg="#055E9E" color="white" zIndex={10}>
-        <Text pl="3.5rem" fontSize="2.25rem" fontWeight="bold">SeeChange</Text>
-      </Flex>
-      <Flex alignItems="center" pos="relative" top={titleBarHeight} py={5}>
+      <Flex alignItems="center" minHeight={`calc(100vh - ${titleBarHeight})`} pos="relative" top={titleBarHeight} py={5}>
+        <Flex alignItems="center" height={titleBarHeight} pos="fixed" top="0" w="100%" bg="#055E9E" color="white" zIndex={10}>
+          <Text pl="3.5rem" fontSize="2.25rem" fontWeight="bold">SeeChange</Text>
+        </Flex>
         <Container centerContent maxW="container.sm">
           {children}
         </Container>

--- a/components/Layout/Layout.jsx
+++ b/components/Layout/Layout.jsx
@@ -13,13 +13,15 @@ export default function Layout({ children }) {
         <meta name="description" content="Emissions calculator" />
         <link rel="icon" href={`${productionUrl}/favicon.ico`} />
       </Head>
-      <Flex alignItems="center" height={titleBarHeight} pos="fixed" top="0" w="100%" bg="#055E9E" color="white" zIndex={10}>
-        <Text pl="3.5rem" fontSize="2.25rem" fontWeight="bold">SeeChange</Text>
-      </Flex>
-      <Flex alignItems="center" minHeight={`calc(100vh - ${titleBarHeight})`} pos="relative" top={titleBarHeight} py={5}>
-        <Container centerContent maxW="container.sm">
-          {children}
-        </Container>
+      <Flex minHeight="100vh" direction="column">
+        <Flex alignItems="center" height={titleBarHeight} top="0" w="100%" bg="#055E9E" color="white" zIndex={10}>
+          <Text pl="3.5rem" fontSize="2.25rem" fontWeight="bold">SeeChange</Text>
+        </Flex>
+        <Flex alignItems="center" minHeight={`calc(100vh - ${titleBarHeight})`} pos="relative" py={5}>
+          <Container centerContent maxW="container.sm">
+            {children}
+          </Container>
+        </Flex>
       </Flex>
     </>
   );

--- a/components/Layout/Layout.jsx
+++ b/components/Layout/Layout.jsx
@@ -1,8 +1,11 @@
 import Head from "next/head";
-import { Container, Flex } from "@chakra-ui/react";
+import { Container, Flex, Text } from "@chakra-ui/react";
 import { productionUrl } from "../../utils/constants";
 
+const titleBarHeight = "80px";
+
 export default function Layout({ children }) {
+
   return (
     <>
       <Head>
@@ -10,7 +13,10 @@ export default function Layout({ children }) {
         <meta name="description" content="Emissions calculator" />
         <link rel="icon" href={`${productionUrl}/favicon.ico`} />
       </Head>
-      <Flex height="100vh" alignItems="center">
+      <Flex alignItems="center" height={titleBarHeight} pos="fixed" top="0" w="100%" bg="#055E9E" color="white" zIndex={10}>
+        <Text pl="3.5rem" fontSize="2.25rem" fontWeight="bold">SeeChange</Text>
+      </Flex>
+      <Flex alignItems="center" pos="relative" top={titleBarHeight} py={5}>
         <Container centerContent maxW="container.sm">
           {children}
         </Container>


### PR DESCRIPTION
#### Links
[gh-pages](https://ymloh.github.io/council-emissions-calculator-spike/form/2)
[trello card](https://trello.com/c/MFHoPHrY/180-dev-sml-update-layout-to-include-title-bar-and-fix-page-positioning-on-smaller-screens)

#### Changes
1. added the [header/titlebar](https://github.com/ymloh/council-emissions-calculator-spike/blob/13ff678ecc5ae4cf91b725d93b8624929244025f/components/Layout/Layout.jsx#L17-L19) as a Flex component. Its currently `position: fixed` so it doesn't move as the page is scrolled <- I have not consulted the designers about this.
2. fixed the vertical cropping issue on smaller screens by changing `height="100vh"` to `minHeight` as the [difference of 100vh and the height of the header](https://github.com/ymloh/council-emissions-calculator-spike/blob/13ff678ecc5ae4cf91b725d93b8624929244025f/components/Layout/Layout.jsx#L17-L19). This also preserves the vertical centering of page content when its height doesn't exceed the viewport height 🎉 

#### Screencaps
<img src="https://user-images.githubusercontent.com/20964807/131420524-4a588fd2-a5c6-461e-b4e1-b229e9f00168.png" width="300px">

<img src="https://user-images.githubusercontent.com/20964807/131430395-9ddb2325-b1f4-4f09-9d3d-707f2339dd27.png" width="300px">


