### PR TITLE
update url for favicon

### DIFF
--- a/components/Layout/Layout.jsx
+++ b/components/Layout/Layout.jsx
@@ -1,6 +1,5 @@
 import Head from "next/head";
 import { Container, Flex, Text } from "@chakra-ui/react";
-import { productionUrl } from "../../utils/constants";
 
 const titleBarHeight = "80px";
 
@@ -11,7 +10,7 @@ export default function Layout({ children }) {
       <Head>
         <title>Emissions Calculator</title>
         <meta name="description" content="Emissions calculator" />
-        <link rel="icon" href={`${productionUrl}/favicon.ico`} />
+        <link rel="icon" href="/favicon.ico" />
       </Head>
       <Flex minHeight="100vh" direction="column">
         <Flex alignItems="center" height={titleBarHeight} top="0" w="100%" bg="#055E9E" color="white" zIndex={10}>

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -20,6 +20,3 @@ export const modesOfTransport = [
 ];
 
 export const departments = ["education", "health", "transport", "finance"];
-
-export const productionUrl =
-  "https://codeforaustralia.github.io/council-emissions-calculator-spike";


### PR DESCRIPTION
This PR fixes a problem with the url of favicon. Currently, url is pointing to [favicon served from github pages](https://codeforaustralia.github.io/council-emissions-calculator-spike/favicon.ico). This should not be. App should use favicon served from current deployment of app.

details of change
- update favicon url to use favicon of current deployment, (and not
  favicon from github pages)
- remove `productionUrl` variable declared in `utils/constants.js`; no
  longer used; will obtain url of app from `NEXT_PUBLIC_HOST`
environment variable moving forward