### PR TITLE
fix next button text colour, default now white

### DIFF
--- a/components/LinkButton/LinkButton.jsx
+++ b/components/LinkButton/LinkButton.jsx
@@ -10,6 +10,7 @@ export default function LinkButton({
   variant = "solid",
   width,
   topMargin,
+  color,
 }) {
   return (
     <Link href={href} passHref>
@@ -29,6 +30,7 @@ export default function LinkButton({
             bg: "#D0D9DF",
           },
         }}
+        color={color || "#fff"}
         onClick={onClick}
         disabled={disabled}
       >


### PR DESCRIPTION
Quick fix so the default text colour on `LinkButton` is now white. 

This should fix the Next button colours on all the pages we have at the moment.