### PR TITLE
fix dropdowns from Q4 and Q5

### DIFF
--- a/pages/form/Question4.jsx
+++ b/pages/form/Question4.jsx
@@ -49,25 +49,25 @@ export default function Question4() {
         <Flex flex={1} flexDirection="column" ms={[0, 10]} mt={[10, 5]}>
           <FormControl isRequired>
             <Select
-              textAlign="center"
               fontWeight="bold"
               onChange={(e) => setSelectedMode(e.target.value)}
               placeholder="Please select"
               border=".2px solid #044B7F"
               height="55px"
+              defaultValue={selectedMode}
+              id="selector"
             >
               {modesOfTransport.map((mode) => (
                 <option
                   fontSize="lg"
                   key={mode}
-                  selected={mode === selectedMode}
                   value={mode}
                 >
                   {mode}
                 </option>
               ))}
             </Select>
-            <FormHelperText>
+            <FormHelperText id="selectorHelper">
               *Required
             </FormHelperText>
           </FormControl>

--- a/pages/form/Question5.jsx
+++ b/pages/form/Question5.jsx
@@ -22,7 +22,6 @@ import Q5Cloud from "../../public/images/clouds/cloud-q5.svg";
 export default function Question5() {
   const { answers, setAnswers } = useForm();
   const [department, setDepartment] = useState(answers.department);
-  console.log(`answers so far: ${JSON.stringify(answers)}`);
 
   const saveAnswers = () =>
     setAnswers((prev) => ({ ...prev, department: department }));
@@ -46,23 +45,24 @@ export default function Question5() {
         <Box width={["100%"]} flex={1} mt={[12, 5]} ms={[0, 5]}>
           <FormControl isRequired>
             <Select
+              fontWeight="bold"
               width="100%"
               height="55px"
               placeholder="Please select"
               onChange={(e) => setDepartment(e.target.value)}
-              textAlign="center"
+              defaultValue={answers.department}
+              id="selector"
             >
               {departments.map((department) => (
                 <option
                   key={department}
                   value={department}
-                  selected={department === answers.department}
                 >
                   {capitalize(department)}
                 </option>
               ))}
             </Select>
-            <FormHelperText>*Required</FormHelperText>
+            <FormHelperText id="selectorHelper">*Required</FormHelperText>
           </FormControl>
           <ContinueButton
             disabled={!department}


### PR DESCRIPTION
- alignment is now left
- selected is now bold
- React complaints about the following have been addressed:
  - id mismatches between virtual and browser DOM
  - prefer `defaultValue` in `select` component to `selected` in `option` element 