### PR TITLE
clear onsite days when switching to hybrid flow

### DIFF
--- a/pages/form/WorkArrangement.jsx
+++ b/pages/form/WorkArrangement.jsx
@@ -27,22 +27,34 @@ export default function WorkArrangement() {
   const [workMode, setWorkMode] = useState(answers.workMode);
 
   const saveAnswers = () => {
-    if (workMode === "wfh") {
-      setAnswers((prev) => ({
-        ...prev,
-        workMode: workMode,
-        numDaysWorked: answers.wfhDays.length,
-        onsiteDays: [],
-      }));
-    } else if (workMode === "onsite") {
-      setAnswers((prev) => ({
-        ...prev,
-        workMode: workMode,
-        numDaysWorked: answers.onsiteDays.length,
-        wfhDays: [],
-      }));
+    if (answers.workMode === workMode) {
+      // if response has not changed, return saved response
+      setAnswers((prev) => ({ ...prev }));
     } else {
-      setAnswers((prev) => ({ ...prev, workMode: workMode }));
+      if (workMode === "wfh") {
+        setAnswers((prev) => ({
+          ...prev,
+          workMode: workMode,
+          numDaysWorked: answers.wfhDays.length,
+          onsiteDays: [],
+        }));
+      } else if (workMode === "onsite") {
+        setAnswers((prev) => ({
+          ...prev,
+          workMode: workMode,
+          numDaysWorked: answers.onsiteDays.length,
+          wfhDays: [],
+        }));
+      } else if (workMode === "hybrid") {
+        setAnswers((prev) => ({
+          ...prev,
+          workMode: workMode,
+          numDaysWorked: answers.onsiteDays.length,
+          onsiteDays: [],
+        }));
+      } else {
+        setAnswers((prev) => ({ ...prev, workMode: workMode }));
+      }
     }
   };
 


### PR DESCRIPTION
## Overview of the Pull Request:
This PR addresses [the feedback here regarding switching from 'onsite' to 'hybrid' flow in `WorkArrangements` page](https://codeforaustralia.slack.com/archives/C01CXCQPF8V/p1652069301656049?thread_ts=1652054520.127719&cid=C01CXCQPF8V):
- when user updates their work arrangement from 'onsite' to 'hybrid', the user's previous 'onsite' days selections will be cleared to avoid confusion when user fills out 'WorkFromHomeDays' selections.
- if there are no changes to work arrangement, the saved responses for 'onsite' days or 'wfh' days should remain unchanged

## How Has This Been Tested?
Reviewers should verify the following behaviour:
- when user updates their work arrangement from 'onsite' to 'hybrid', the user's previous 'onsite' days selections will be cleared (ie, user will have to fill out their selections again on `WorkOnSiteDays` page)
- if there are no changes to work arrangement, the saved responses for 'onsite' days or 'wfh' days should remain unchanged

## Pull Request Checklist:

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [ ] ~Have you included a link Trello card / Github issue and written sufficient description to help others review your work?~
- [x] Is your pull request up-to-date with `main` branch?
- [x] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [x] Have you written instructions on how to test that your changes work as expected?
- [x] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
