### PR TITLE
add shade for Distribution of commute distance

### DIFF
--- a/components/ResultsPageComponents/CommuteDistanceDistribution/CommuteDistanceDistribution.jsx
+++ b/components/ResultsPageComponents/CommuteDistanceDistribution/CommuteDistanceDistribution.jsx
@@ -16,7 +16,13 @@ export default function CommuteDistanceDistribution({ data }) {
       justify="center"
     >
       <Flex direction="column" width="100%">
-        <Text as="h2" fontWeight={600} fontSize="33px" lineHeight="37px" py="15px">
+        <Text
+          as="h2"
+          fontWeight={600}
+          fontSize="33px"
+          lineHeight="37px"
+          py="15px"
+        >
           Distribution of commute distance
         </Text>
         <Text fontSize="19px" py="15px" width="100%">
@@ -25,10 +31,16 @@ export default function CommuteDistanceDistribution({ data }) {
           distances staff travel to work, and how they are distributed along
           those distances.
         </Text>
-        <CommuteDistanceDistributionChart
-          title="Distribution of commute distances"
-          data={data["commute-distance-distribution"]}
-        />
+        <Flex
+          boxShadow="0px 0px 22.5px rgba(35, 47, 78, 0.18)"
+          maxWidth="634px"
+          mt="20px"
+        >
+          <CommuteDistanceDistributionChart
+            title="Distribution of commute distances"
+            data={data["commute-distance-distribution"]}
+          />
+        </Flex>
       </Flex>
     </Flex>
   );


### PR DESCRIPTION
## Overview of the Pull Request:
Add missing shade for Distribution of Commute Distance chart.

## link to Trello card or Github issue

## How Has This Been Tested?
- Previewed on localhos:3000/results
- Shade is seen and achieved the desired outcome.


## Pull Request Checklist:

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [ ✔️] Have you included a link Trello card / Github issue and written sufficient description to help others review your work?
- [ ✔️] Is your pull request up-to-date with `main` branch?
- [ ✔️] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
