### PR TITLE
Change travel method casing

### DIFF
--- a/data/2022-results.json
+++ b/data/2022-results.json
@@ -26,7 +26,7 @@
         "count": 11651
       },
       {
-        "name": "Train/Tram",
+        "name": "Train/tram",
         "count": 1020
       },
       {
@@ -40,7 +40,7 @@
         "count": 796
       },
       {
-        "name": "Walk/Run",
+        "name": "Walk/run",
         "count": 106
       },
       {
@@ -58,7 +58,7 @@
         "count": 0.034
       },
       {
-        "name": "Train/Tram",
+        "name": "Train/tram",
         "count": 0.03
       }
     ]
@@ -107,7 +107,7 @@
       "count": 6
     },
     {
-      "name": "Taxi/Share",
+      "name": "Taxi/share",
       "count": 0
     },
     {
@@ -115,11 +115,11 @@
       "count": 796
     },
     {
-      "name": "Walk/Run",
+      "name": "Walk/run",
       "count": 106
     },
     {
-      "name": "Train/Tram",
+      "name": "Train/tram",
       "count": 42
     }
   ]

--- a/data/2022-results.json
+++ b/data/2022-results.json
@@ -26,7 +26,7 @@
         "count": 11651
       },
       {
-        "name": "Train/tram",
+        "name": "Train/Tram",
         "count": 1020
       },
       {
@@ -40,7 +40,7 @@
         "count": 796
       },
       {
-        "name": "Walk/run",
+        "name": "Walk/Run",
         "count": 106
       },
       {
@@ -58,7 +58,7 @@
         "count": 0.034
       },
       {
-        "name": "Train/tram",
+        "name": "Train/Tram",
         "count": 0.03
       }
     ]
@@ -119,7 +119,7 @@
       "count": 106
     },
     {
-      "name": "Train/tram",
+      "name": "Train/Tram",
       "count": 42
     }
   ]

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -22,10 +22,10 @@ export const travelMethods = [
   "Bus",
   "Carpool",
   "Motorbike",
-  "Taxi/Ride share",
+  "Taxi/ride share",
   "Car",
-  "Walk/Run", 
-  "Train/Tram",
+  "Walk/run", 
+  "Train/tram",
 ];
 
 export const transportIcon = [

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -22,10 +22,10 @@ export const travelMethods = [
   "Bus",
   "Carpool",
   "Motorbike",
-  "Taxi/ride Share",
+  "Taxi/Ride share",
   "Car",
-  "Walk/run", 
-  "Train/tram",
+  "Walk/Run", 
+  "Train/Tram",
 ];
 
 export const transportIcon = [


### PR DESCRIPTION
## Overview of the Pull Request:
- Change travel method button casing to sentence one;
- Change the results Page (that data is displayed on the charts, thought it's good to make it consistent);

Had doubdts about choice options (`Xxxxx/Yyyyy`, example `Walk/Run`), if we keen all words in selection capital it's called title case, not the sentence case. For proper sentence casing only first letter in a sentence is capital. 

On a separate note, while working on the card, I realised the chart headers also have inconsistent casing. New card is created here: https://trello.com/c/QlMmOXCT

## link to Trello card or Github issue
Trello card: https://trello.com/c/bIR3LFt9

## How Has This Been Tested?
- Check the page for travel method selection (form has to be filled to reach the page): https://council-emissions-calculator-spike-git-5ee477-codeforaustralia.vercel.app
- CHeck the results page: https://council-emissions-calculator-spike-git-5ee477-codeforaustralia.vercel.app/results 

## Pull Request Checklist:

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [x] Have you included a link Trello card / Github issue and written sufficient description to help others review your work?
- [x] Is your pull request up-to-date with `main` branch?
- [x] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [x] Have you written instructions on how to test that your changes work as expected?
- [x] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
