### PR TITLE
Added Link back to home page on click of logo

### DIFF
--- a/components/Layout/Layout.jsx
+++ b/components/Layout/Layout.jsx
@@ -48,39 +48,36 @@ export function Header({ isText, Progress }) {
       color="white"
       zIndex={10}
     >
-      {isText ? 
-      (
+      {isText ? (
         <Box flex={1}>
           {["/", "/form/Thankyou"].includes(router.pathname) ? (
-          <Link href="/" passHref>
-            <Text
-              fontSize={["24px", "30px"]}
-              fontWeight="bold"
-              flex={1}
-              textAlign="center"
-              marginStart={[10, 0]}
-            >
-              SeeChange
-            </Text>
-          </Link>
-        ) : (
-          <Link href="/" passHref>
-            <Text
-              fontSize={["24px", "30px"]}
-              fontWeight="bold"
-              flex={1}
-              display = {["none", "block"]}
-              textAlign="center"
-              overflow="hidden"
-            >
-              SeeChange
-            </Text>
-          </Link>
-        )}
+            <Link href="/" passHref>
+              <Text
+                fontSize={["24px", "30px"]}
+                fontWeight="bold"
+                flex={1}
+                textAlign="center"
+                marginStart={[10, 0]}
+              >
+                SeeChange
+              </Text>
+            </Link>
+          ) : (
+            <Link href="/" passHref>
+              <Text
+                fontSize={["24px", "30px"]}
+                fontWeight="bold"
+                flex={1}
+                display={["none", "block"]}
+                textAlign="center"
+                overflow="hidden"
+              >
+                SeeChange
+              </Text>
+            </Link>
+          )}
         </Box>
-      ) 
-      : 
-      (
+      ) : (
         <Box flex={1}></Box>
       )}
       <Flex flex={1} justifyContent="center" w="100%">

--- a/components/Layout/Layout.jsx
+++ b/components/Layout/Layout.jsx
@@ -1,4 +1,5 @@
 import Head from "next/head";
+import Link from "next/link";
 import { Container, Flex, Text, Box } from "@chakra-ui/react";
 import { useRouter } from "next/router";
 
@@ -47,30 +48,39 @@ export function Header({ isText, Progress }) {
       color="white"
       zIndex={10}
     >
-      {isText ? (
-        ["/", "/form/Thankyou"].includes(router.pathname) ? (
-          <Text
-            fontSize={["24px", "30px"]}
-            fontWeight="bold"
-            flex={1}
-            textAlign="center"
-            marginStart={[10, 0]}
-          >
-            SeeChange
-          </Text>
+      {isText ? 
+      (
+        <Box flex={1}>
+          {["/", "/form/Thankyou"].includes(router.pathname) ? (
+          <Link href="/" passHref>
+            <Text
+              fontSize={["24px", "30px"]}
+              fontWeight="bold"
+              flex={1}
+              textAlign="center"
+              marginStart={[10, 0]}
+            >
+              SeeChange
+            </Text>
+          </Link>
         ) : (
-          <Text
-            fontSize={["24px", "30px"]}
-            fontWeight="bold"
-            flex={1}
-            visibility={["hidden", "visible"]}
-            textAlign="center"
-            overflow="hidden"
-          >
-            SeeChange
-          </Text>
-        )
-      ) : (
+          <Link href="/" passHref>
+            <Text
+              fontSize={["24px", "30px"]}
+              fontWeight="bold"
+              flex={1}
+              display = {["none", "block"]}
+              textAlign="center"
+              overflow="hidden"
+            >
+              SeeChange
+            </Text>
+          </Link>
+        )}
+        </Box>
+      ) 
+      : 
+      (
         <Box flex={1}></Box>
       )}
       <Flex flex={1} justifyContent="center" w="100%">


### PR DESCRIPTION
fixes #224 

## Overview of the Pull Request:
- Wrapped the text component of SeeChange logo with a Link component with href="/"
- changed the visibility of hidden and visible for mobile and desktop screens to display of none and block. This was done because the logo is still clickable if the element is hidden.

## link to Trello card or Github issue
Trello - https://trello.com/c/n5RPlQI6/26-dev-add-link-back-to-home-page-to-seechange-logo

## How Has This Been Tested?
- Started the survey, clicked on the SeeChange logo, it brought me back to the home page.
- When SeeChange logo is clicked in the home page itself, nothing happens as its already in the home page.

## Pull Request Checklist:

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [x] Have you included a link Trello card / Github issue and written sufficient description to help others review your work?
- [x] Is your pull request up-to-date with `main` branch?
- [x] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [x] Have you written instructions on how to test that your changes work as expected?
- [x] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
